### PR TITLE
Adding support for Blob type

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # extract-files changelog
 
+## 3.1.0
+
+* Added support for [`Blob`](https://developer.mozilla.org/en/docs/Web/API/Blob) types.
+
 ## 3.0.0
 
 * Updated dependencies.

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 # extract-files changelog
 
-## 3.1.0
+## Next
 
 * Added support for [`Blob`](https://developer.mozilla.org/en/docs/Web/API/Blob) types.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "extract-files",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Reversibly extracts files from an object tree.",
   "license": "MIT",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "extract-files",
-  "version": "3.1.0",
+  "version": "3.0.0",
   "description": "Reversibly extracts files from an object tree.",
   "license": "MIT",
   "author": {

--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@ Reversibly extracts files from a tree object.
 
 Files are extracted along with their object path to allow reassembly and are replaced with `null` in the original tree.
 
-Files may be [`File`](https://developer.mozilla.org/en/docs/Web/API/File), [`Blob`]('https://developer.mozilla.org/en/docs/Web/API/Blob') and [`ReactNativeFile`](https://github.com/jaydenseric/extract-files#react-native) instances. [`FileList`](https://developer.mozilla.org/en/docs/Web/API/FileList) instances are converted to arrays and the items are extracted as `File` instances.
+Files may be [`File`](https://developer.mozilla.org/en/docs/Web/API/File), [`Blob`](https://developer.mozilla.org/en/docs/Web/API/Blob) and [`ReactNativeFile`](https://github.com/jaydenseric/extract-files#react-native) instances. [`FileList`](https://developer.mozilla.org/en/docs/Web/API/FileList) instances are converted to arrays and the items are extracted as `File` instances.
 
 ## Usage
 

--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@ Reversibly extracts files from a tree object.
 
 Files are extracted along with their object path to allow reassembly and are replaced with `null` in the original tree.
 
-Files may be [`File`](https://developer.mozilla.org/en/docs/Web/API/File) and [`ReactNativeFile`](https://github.com/jaydenseric/extract-files#react-native) instances. [`FileList`](https://developer.mozilla.org/en/docs/Web/API/FileList) instances are converted to arrays and the items are extracted as `File` instances.
+Files may be [`File`](https://developer.mozilla.org/en/docs/Web/API/File), [`Blob`]('https://developer.mozilla.org/en/docs/Web/API/Blob') and [`ReactNativeFile`](https://github.com/jaydenseric/extract-files#react-native) instances. [`FileList`](https://developer.mozilla.org/en/docs/Web/API/FileList) instances are converted to arrays and the items are extracted as `File` instances.
 
 ## Usage
 
@@ -30,13 +30,13 @@ Extracted files are an array:
 ```js
 [{
   path: 'tree.foo',
-  file: /* File instance */
+  file: /* File or Blob instance */
 }, {
   path: 'tree.bar.0',
-  file: /* File instance */
+  file: /* File or Blob instance */
 }, {
   path: 'tree.bar.1',
-  file: /* File instance */
+  file: /* File or Blob instance */
 }]
 ```
 

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -31,6 +31,8 @@ export default function extractFiles(tree, treePath = '') {
       if (
         // Node is a File.
         (typeof File !== 'undefined' && node[key] instanceof File) ||
+        // Node is a Blob.
+        (typeof Blob !== 'undefined' && node[key] instanceof Blob) ||
         // Node is a ReactNativeFile.
         node[key] instanceof ReactNativeFile
       ) {


### PR DESCRIPTION
Support for Blob type has been added.

PRs have also been sent for apollo-upload-client, apollo-upload-server and apollo-upload-examples.

The only thing missing here are the tests because Blob isn't natively supported by Node...
I couldn't find a proper way to mock them so I just omitted the tests.

If anyone can help me with the tests, I'm open to suggestions 👍 