### PR TITLE
fix check for objects. Handles dates as primitives

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # extract-files changelog
 
+## Next
+
+### Patch
+
+- Instance (e.g. [`new Date()`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date)) references are copied to the clone instead of recursed as objects; fixing [jaydenseric/apollo-upload-client#138](https://github.com/jaydenseric/apollo-upload-client/issues/138) via [#9](https://github.com/jaydenseric/extract-files/pull/9).
+
 ## 5.0.0
 
 ### Major

--- a/src/extractFiles.mjs
+++ b/src/extractFiles.mjs
@@ -87,11 +87,7 @@ export function extractFiles(value, path = '') {
         result.files.forEach(addFile)
         return result.clone
       })
-    else if (
-      value &&
-      typeof value == 'object' &&
-      value.constructor === Object
-    ) {
+    else if (value && value.constructor === Object) {
       clone = {}
       for (const i in value) {
         const result = extractFiles(value[i], `${prefix}${i}`)

--- a/src/extractFiles.mjs
+++ b/src/extractFiles.mjs
@@ -87,7 +87,11 @@ export function extractFiles(value, path = '') {
         result.files.forEach(addFile)
         return result.clone
       })
-    else if (value && typeof value == 'object') {
+    else if (
+      value &&
+      typeof value == 'object' &&
+      value.constructor === Object
+    ) {
       clone = {}
       for (const i in value) {
         const result = extractFiles(value[i], `${prefix}${i}`)

--- a/src/test.mjs
+++ b/src/test.mjs
@@ -224,7 +224,8 @@ t.test('Handles an object value with various property types.', t => {
       c: true,
       d: false,
       e: null,
-      f: undefined
+      f: undefined,
+      g: new Date(2019, 0, 20)
     }),
     {
       clone: {
@@ -233,7 +234,8 @@ t.test('Handles an object value with various property types.', t => {
         c: true,
         d: false,
         e: null,
-        f: undefined
+        f: undefined,
+        g: new Date(2019, 0, 20)
       },
       files: new Map()
     },


### PR DESCRIPTION
Improved check for objects, so dates are handled correctly.
Fixes jaydenseric/apollo-upload-client#138
