### PR TITLE
Fix: extract files from class instances

### DIFF
--- a/src/public/extractFiles.js
+++ b/src/public/extractFiles.js
@@ -106,7 +106,7 @@ module.exports = function extractFiles(
         result.files.forEach(addFile);
         return result.clone;
       });
-    else if (value && value.constructor === Object) {
+    else if (value && !builtInConstructors.includes(value.constructor)) {
       clone = {};
       for (const i in value) {
         const result = extractFiles(
@@ -122,3 +122,13 @@ module.exports = function extractFiles(
 
   return { clone, files };
 };
+
+const builtInConstructors = [
+  String,
+  Number,
+  Boolean,
+  Array,
+  RegExp,
+  Function,
+  Date,
+];

--- a/test/public/extractFiles.test.js
+++ b/test/public/extractFiles.test.js
@@ -141,6 +141,25 @@ module.exports = (tests) => {
     strictEqual(input.b, fileB);
   });
 
+  tests.add(
+    '`extractFiles` with an instance of a class containing a file.',
+    () => {
+      class RandomClass {
+        constructor(file) {
+          this.file = file;
+        }
+      }
+      const file = new ReactNativeFile({ uri: '', name: '', type: '' });
+      const input = new RandomClass(file);
+
+      deepStrictEqual(extractFiles(input), {
+        clone: { file: null },
+        files: new Map([[file, ['file']]]),
+      });
+      strictEqual(input.file, file);
+    }
+  );
+
   tests.add('`extractFiles` with a nested object containing a file.', () => {
     const file = new ReactNativeFile({ uri: '', name: '', type: '' });
     const input = { a: { a: file } };


### PR DESCRIPTION
So, we've encountered the same problem as described here: https://github.com/jaydenseric/apollo-upload-client/issues/199.
Relevant test provided.

We're using classes to describe our forms, and it wasn't a fun debugging session finding out why in one case our file is uploaded normally, but in the other it's not.